### PR TITLE
Expose websocket handshake state

### DIFF
--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -65,6 +65,10 @@ impl<S> Websocket<S> {
     pub fn closed(&self) -> bool {
         self.closed
     }
+
+    pub fn handshake_complete(&self) -> bool {
+        matches!(self.handshaker.state(), HandshakeState::Completed)
+    }
 }
 
 #[cfg(feature = "mio")]

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -66,7 +66,7 @@ impl<S> Websocket<S> {
         self.closed
     }
 
-    pub fn handshake_complete(&self) -> bool {
+    pub const fn handshake_complete(&self) -> bool {
         matches!(self.handshaker.state(), HandshakeState::Completed)
     }
 }


### PR DESCRIPTION
According to the web socket [spec](https://datatracker.ietf.org/doc/html/rfc6455#section-4.1):

>   Once the client's opening handshake has been sent, the client MUST wait for a response from the server before sending any further data.
   
 With the current API it is not possible to know if the handshake is completed and `send_text` can be called. This MR adds a `handshake_completed` function to know if the handshake completed.
 
The other API change is to introduce an error if `send_text` is called before the handshake is completed. In almost any case this is not what the user wants since the endpoint can respond in arbitrary ways (in my case it was an EOF) which can cause painful debugging. This change might is breaking and I can remove it.



