### PR TITLE
Bugfix/openssl certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 scratch
 massif.out.*
 *.log
+*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 mio = ["dep:mio"]
 rustls-native = ["rustls", "rustls-native-certs"]
 rustls-webpki = ["rustls", "webpki-roots"]
-openssl = ["dep:openssl"]
+openssl = ["dep:openssl", "dep:openssl-probe"]
 http = ["dep:http", "httparse", "memchr", "itoa"]
 ws = ["rand", "base64", "dep:http", "httparse"]
 ext = []
@@ -36,6 +36,7 @@ base64 = { version = "0.21.5", optional = true }
 httparse = { version = "1.8.0", optional = true }
 http = { version = "1.0.0", optional = true }
 openssl = { version = "0.10.70", features = ["vendored"], optional = true }
+openssl-probe = { version = "0.1.6", optional = true }
 memchr = { version = "2.7.4", optional = true }
 itoa = { version = "1.0.15", optional = true }
 smallvec = "1.15.0"


### PR DESCRIPTION
When running the binaries they fail with `self-signed certificate in certificate chain` but if you run using cargo you don't get this error.

This is because cargo leaks env vars that openssl uses.  When you use the openssl crate with the vendored feature flag, some compile time values are not set so it does not have any default search paths for the certs/ca files and only relies on the env vars which may not be set.

Updated to use the method outlined in the docs https://docs.rs/openssl/latest/openssl/#vendored