### PR TITLE
Unknown opcode support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.87.0"
 all-features = true
 
 [features]
-default = ["ws"]
+default = []
 mio = ["dep:mio"]
 rustls-native = ["rustls", "rustls-native-certs"]
 rustls-webpki = ["rustls", "webpki-roots"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.87.0"
 all-features = true
 
 [features]
-default = []
+default = ["ws"]
 mio = ["dep:mio"]
 rustls-native = ["rustls", "rustls-native-certs"]
 rustls-webpki = ["rustls", "webpki-roots"]

--- a/src/ws/decoder.rs
+++ b/src/ws/decoder.rs
@@ -124,7 +124,7 @@ impl Decoder {
                             protocol::op::CONTINUATION_FRAME => WebsocketFrame::Continuation(self.fin, payload),
                             protocol::op::PING => WebsocketFrame::Ping(payload),
                             protocol::op::CONNECTION_CLOSE => WebsocketFrame::Close(payload),
-                            _ => return Err(Error::Protocol("unknown op_code")),
+                            _ => WebsocketFrame::Unknown(self.op_code, payload),
                         };
                         self.decode_state = DecodeState::ReadingHeader;
                         return Ok(Some(frame));

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -94,6 +94,9 @@ pub enum WebsocketFrame {
     /// Server has sent close frame. The websocket will be closed as a result. This frame is not
     /// exposed to the user.
     Close(&'static [u8]),
+    /// Server has sent an opcode that boomnet does not support. It is up to the user to handle the
+    /// outcome of an Unknown opcode
+    Unknown(u8, &'static [u8]),
 }
 
 /// Websocket client that owns underlying stream.


### PR DESCRIPTION
Hey, back here.

Currently when boomnet receives an unsupported opcode outside of the set of the 'typical' ws opcodes, it returns an error.

In this PR I am proposing a change for the user of the websocket to choose how they handle the opcode instead of erroring.