### PR TITLE
Add support for sending close frames from the stream

### DIFF
--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -229,7 +229,9 @@ impl<S: Read + Write> Websocket<S> {
 
     #[inline]
     pub fn send_close(&mut self) -> Result<(), Error> {
-        self.send(true, protocol::op::CONNECTION_CLOSE, None)
+        self.send(true, protocol::op::CONNECTION_CLOSE, None)?;
+        self.closed = true;
+        Ok(())
     }
 
     #[inline]

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -228,6 +228,11 @@ impl<S: Read + Write> Websocket<S> {
     }
 
     #[inline]
+    pub fn send_close(&mut self) -> Result<(), Error> {
+        self.send(true, protocol::op::CONNECTION_CLOSE, None)
+    }
+
+    #[inline]
     fn next(&mut self) -> Result<Option<WebsocketFrame>, Error> {
         self.ensure_not_closed()?;
         match self.state.next(&mut self.stream) {


### PR DESCRIPTION
Hello,

Was wondering if we can support explicit stream closes through sending a close frame on the stream. I understand there is auto disconnect features built into the IOService but I think it would be nice to be able to arbitrarily send a close frame from the stream as well.