### PR TITLE
[WIP] refactor IOService::dispatch

### DIFF
--- a/examples/io_service_dispatch.rs
+++ b/examples/io_service_dispatch.rs
@@ -1,6 +1,7 @@
 use crate::common::TradeEndpoint;
 use boomnet::service::IntoIOService;
 use boomnet::service::select::mio::MioSelector;
+use std::io::ErrorKind;
 
 #[path = "common/mod.rs"]
 mod common;
@@ -16,14 +17,10 @@ fn main() -> anyhow::Result<()> {
 
     // we delay the subscription until the endpoint is ready
     loop {
-        let success = io_service.dispatch(handle, |ws, endpoint| {
-            endpoint.subscribe(ws)?;
-            Ok(())
-        })?;
-        if success.is_some() {
-            break;
-        } else {
-            io_service.poll(|ws, endpoint| endpoint.poll(ws))?;
+        match io_service.dispatch(handle, |ws, endpoint| endpoint.subscribe(ws)) {
+            Ok(_) => break,
+            Err(err) if err.kind() == ErrorKind::NotConnected => io_service.poll(|ws, endpoint| endpoint.poll(ws))?,
+            Err(err) => Err(err)?,
         }
     }
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -348,21 +348,23 @@ where
         Ok(())
     }
 
-    /// Dispatch command to an active endpoint using `handle` and provided `action`. If the
-    /// endpoint is currently active `Ok(Some(...))` will be returned and the provided `action` invoked,
-    /// otherwise this method will return `Ok(None)` and no `action` will be invoked.
-    pub fn dispatch<F, T>(&mut self, handle: Handle, mut action: F) -> io::Result<Option<T>>
+    /// Dispatch an `action` to an active endpoint using `handle`.
+    ///
+    /// If the endpoint has a socket descriptor, the `action` is invoked
+    /// and its result returned.
+    ///
+    /// Returns `std::io::Error` with `ErrorKind::NotConnected` while the endpoint is
+    /// awaiting resolution by [DnsResolver].
+    pub fn dispatch<F, T>(&mut self, handle: Handle, mut action: F) -> io::Result<T>
     where
         F: FnMut(&mut E::Target, &mut E) -> std::io::Result<T>,
     {
-        match self.io_nodes.get_mut(&handle.0) {
-            Some(io_node) => {
-                let (stream, (_, endpoint)) = io_node.as_parts_mut();
-                let result = action(stream, endpoint)?;
-                Ok(Some(result))
-            }
-            None => Ok(None),
-        }
+        let io_node = self
+            .io_nodes
+            .get_mut(&handle.0)
+            .ok_or(io::Error::new(ErrorKind::NotConnected, ""))?;
+        let (stream, (_, endpoint)) = io_node.as_parts_mut();
+        action(stream, endpoint)
     }
 }
 


### PR DESCRIPTION
This PR removes unnecessary `Option` from `IOService::dispatch` return value. The lack of socket descriptor now leads to `ErrorKind::NotConnected` instead of `Ok(None)`